### PR TITLE
Allow option to run the cron on service startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ To configure which roles should be attributed to the administrative units of whi
 ## Environment variables
 
 - `CRON_PATTERN`: The cron pattern definning when the healing happens. Defaults to `0 0 * * * *` (every hour)
+- `RUN_CRON_ON_START`: Run the cronjob at startup. Defaults to `false`

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 import { app, errorHandler } from 'mu';
 import { CronJob } from 'cron';
-import { CRON_PATTERN } from './config';
+import { CRON_PATTERN, RUN_CRON_ON_START } from './config';
 import { deleteDanglingAccounts, createMissingAccounts } from './queries';
 
 new CronJob(CRON_PATTERN, async function() {
@@ -11,7 +11,7 @@ new CronJob(CRON_PATTERN, async function() {
   } catch (err) {
     console.log(`An error occurred during mock-login accounts healing at ${now}: ${err}`)
   }
-}, null, true);
+}, null, true, null, null, RUN_CRON_ON_START);
 
 /**
  *

--- a/config.js
+++ b/config.js
@@ -1,4 +1,5 @@
 export const CRON_PATTERN = process.env.CRON_PATTERN || '0 0 * * * *'; // every hour
+const RUN_CRON_ON_START = process.env.RUN_CRON_ON_START || false;
 
 export const PREFIXES = `
   PREFIX foaf: <http://xmlns.com/foaf/0.1/>


### PR DESCRIPTION
Instead of waiting an hour for the cron to trigger, you can set this env to true and it will always execute on startup