### PR TITLE
Add GROUP_TYPE environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,12 @@ To configure which roles should be attributed to the administrative units of whi
 
 ```
 
-## Environment variables
+## Environment Variables
 
-- `CRON_PATTERN`: The cron pattern definning when the healing happens. Defaults to `0 0 * * * *` (every hour)
-- `RUN_CRON_ON_START`: Run the cronjob at startup. Defaults to `false`
+This project uses the following environment variables:
+
+| Variable        | Description                                                                                      | Default Value                                                | Required |
+|-----------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------|----------|
+| CRON_PATTERN    | The cron pattern defining when the healing happens.                                              | `0 0 * * * *` (every hour)                                   | No       |
+| RUN_CRON_ON_START | Run the cronjob at startup.                                                                    | `false`                                                      | No       |
+| GROUP_TYPE      | Used as the `rdf:type` of the group related to the mock login account.                   | `http://data.vlaanderen.be/ns/besluit#Bestuurseenheid`       | No       |

--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 export const CRON_PATTERN = process.env.CRON_PATTERN || '0 0 * * * *'; // every hour
 export const RUN_CRON_ON_START = process.env.RUN_CRON_ON_START || false;
+export const GROUP_TYPE = process.env.GROUP_TYPE || "besluit:Bestuurseenheid";
 
 export const PREFIXES = `
   PREFIX foaf: <http://xmlns.com/foaf/0.1/>

--- a/queries.js
+++ b/queries.js
@@ -1,6 +1,6 @@
 import { updateSudo as update, querySudo as query } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeString, sparqlEscapeUri } from 'mu';
-import { PREFIXES } from './config';
+import { GROUP_TYPE, PREFIXES } from './config';
 import { rules } from '/config/rules';
 
 export async function deleteDanglingAccounts() {
@@ -20,7 +20,7 @@ export async function deleteDanglingAccounts() {
 
         ?account ?paccount ?oaccount .
       }
-      FILTER NOT EXISTS { ?bestuur a besluit:Bestuurseenheid . }
+      FILTER NOT EXISTS { ?bestuur a ${GROUP_TYPE} . }
     }
   `;
   await update(q);
@@ -31,7 +31,7 @@ export async function createMissingAccounts() {
     ${PREFIXES}
     SELECT DISTINCT ?bestuur
     WHERE {
-      ?bestuur a besluit:Bestuurseenheid ;
+      ?bestuur a ${GROUP_TYPE} ;
         besluit:classificatie|org:classification ?classification .
 
       FILTER NOT EXISTS { ?person foaf:member ?bestuur . }
@@ -49,7 +49,7 @@ export async function createMissingAccounts() {
             ${sparqlEscapeUri(bestuur)}
           }
 
-        ?bestuur a besluit:Bestuurseenheid ;
+        ?bestuur a ${GROUP_TYPE} ;
           besluit:classificatie|org:classification ?classification .
         }`;
 
@@ -106,7 +106,7 @@ export async function createMissingAccounts() {
           }
         }
         WHERE {
-          ${sparqlEscapeUri(bestuur)} a besluit:Bestuurseenheid ;
+          ${sparqlEscapeUri(bestuur)} a ${GROUP_TYPE} ;
             mu:uuid ?uuid ;
             skos:prefLabel ?label ;
             besluit:classificatie|org:classification ?classification .


### PR DESCRIPTION
This service both creates and DELETES dangling accounts without bestuurseenheid type. This means verenigingen accounts without type bestuurseenheid get deleted. We want to be able to tell this service to look at org:Organization instead of besluit:Bestuurseenheid to determin if a account is dangling or not and be deleted. 

TLDR
- Added GROUP_TYPE  env for rdf:type
- Default to besluit:Bestuurseenheid
- update Readme