### PR TITLE
Heal mock account names

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,11 @@
 import { app, errorHandler } from 'mu';
 import { CronJob } from 'cron';
 import { CRON_PATTERN, RUN_CRON_ON_START } from './config';
-import { deleteDanglingAccounts, createMissingAccounts } from './queries';
+import {
+  deleteDanglingAccounts,
+  createMissingAccounts,
+  updateMismatchingNames
+} from './queries';
 
 new CronJob(CRON_PATTERN, async function() {
   const now = new Date().toISOString();
@@ -20,6 +24,7 @@ async function healMockLoginAccounts() {
   try {
     await deleteDanglingAccounts();
     await createMissingAccounts();
+    await updateMismatchingNames();
   } catch (err) {
     console.log(`An error occurred: ${err}`);
 

--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
 export const CRON_PATTERN = process.env.CRON_PATTERN || '0 0 * * * *'; // every hour
-export const RUN_CRON_ON_START = process.env.RUN_CRON_ON_START || false;
+export const RUN_CRON_ON_START = process.env.RUN_CRON_ON_START == "true" ? true : false;
 export const GROUP_TYPE = process.env.GROUP_TYPE || "besluit:Bestuurseenheid";
 
 export const PREFIXES = `

--- a/queries.js
+++ b/queries.js
@@ -129,3 +129,29 @@ export async function createMissingAccounts() {
     }
   }
 }
+
+export async function updateMismatchingNames() {
+  const q = `
+    ${PREFIXES}
+    DELETE {
+      GRAPH ?g {
+        ?person <http://xmlns.com/foaf/0.1/familyName> ?nameAccount .
+      }
+    } INSERT {
+      GRAPH ?g {
+        ?person <http://xmlns.com/foaf/0.1/familyName> ?nameBestuur .
+      }
+    } WHERE {
+      GRAPH ?g {
+        ?person a <http://xmlns.com/foaf/0.1/Person> ;
+          foaf:member ?bestuur ;
+          <http://xmlns.com/foaf/0.1/familyName> ?nameAccount .
+      }
+      GRAPH <http://mu.semte.ch/graphs/public> {
+        ?bestuur skos:prefLabel ?nameBestuur
+      }
+      FILTER (?nameAccount != ?nameBestuur)
+    }
+  `;
+  await update(q);
+}


### PR DESCRIPTION
# Context

[DL-6482]

## Main quest

When the name of a administrative unit gets updated in OP, the mock-login account names associated with this administrative units are not automatically updated. This PR introduces a healing on the names to fix this issue.

## Side quest

While testing the update, I noticed that the `RUN_CRON_ON_START` was considered `true` even if I set it to `false` in the docker-compose.yml configuration because any non-empty value was considered `true`. I also fixed it while I was at it.

# How to test it

See instructions in https://github.com/lblod/app-digitaal-loket/pull/654